### PR TITLE
feature/fifthHomeWork

### DIFF
--- a/FinApp/Resources/en.lproj/Localizable.strings
+++ b/FinApp/Resources/en.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "title.todayExpenses" = "Today’s Expenses";
 "title.todayIncome" = "Today’s Income";
 "title.myHistory" = "My History";
+"title.myAnalisys" = "My Analisys";
 "title.myItems" = "My Categories";
 "title.search" = "Search";
 "title.operations" = "OPERATIONS";

--- a/FinApp/Resources/ru.lproj/Localizable.strings
+++ b/FinApp/Resources/ru.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "title.todayExpenses" = "Расходы сегодня";
 "title.todayIncome" = "Доходы сегодня";
 "title.myHistory" = "Моя история";
+"title.myAnalisys" = "Мой анализ";
 "title.myItems" = "Мои статьи";
 "title.search" = "Поиск";
 "title.operations" = "ОПЕРАЦИИ";

--- a/FinApp/Services/TransactionsService.swift
+++ b/FinApp/Services/TransactionsService.swift
@@ -34,54 +34,54 @@ final class TransactionsService {
         let mockAmount3 = Decimal(99999.60)
 
         guard
-            let salaryDate = isoFormatter.date(from: "2025-06-21T10:00:00Z"),
-            let groceriesDate = isoFormatter.date(from: "2025-05-20T15:00:00Z"),
-            let mockDate1 = isoFormatter.date(from: "2025-06-18T15:01:23Z"),
-            let mockDate2 = isoFormatter.date(from: "2025-06-21T15:06:40Z"),
-            let mockDate3 = isoFormatter.date(from: "2025-06-21T15:23:33Z")
+            let salaryDate = isoFormatter.date(from: "2025-07-12T10:00:00Z"),
+            let groceriesDate = isoFormatter.date(from: "2025-06-12T15:00:00Z"),
+            let mockDate1 = isoFormatter.date(from: "2025-07-12T15:01:23Z"),
+            let mockDate2 = isoFormatter.date(from: "2025-07-12T15:06:40Z"),
+            let mockDate3 = isoFormatter.date(from: "2025-07-12T15:23:33Z")
         else {
             fatalError("Error when creating mock data: invalid Date")
         }
 
         let account = AccountBrief(
-            id: 1,
+            id: 0,
             name: "Основной счёт",
             balance: mainBalance,
             currency: "RUB"
         )
 
         let salaryCategory = Category(
-            id: 1,
+            id: 22,
             name: "зп",
             emoji: "💰",
             direction: .income
         )
 
         let groceriesCategory = Category(
-            id: 2,
+            id: 33,
             name: "продукты в шестёрочке",
             emoji: "🛒",
             direction: .outcome
         )
 
         let mockCategory1 = Category(
-            id: 3,
+            id: 44,
             name: "продукты в лавке",
             emoji: "🛒",
             direction: .outcome
         )
 
         let mockCategory2 = Category(
-            id: 3,
+            id: 55,
             name: "Dark Souls 3 в стиме",
             emoji: "🛒",
             direction: .outcome
         )
 
         let mockCategory3 = Category(
-            id: 3,
+            id: 66,
             name: "выхлоп с темки",
-            emoji: "🛒",
+            emoji: "💰",
             direction: .income
         )
 

--- a/FinApp/ViewModels/TransactionFormViewModel.swift
+++ b/FinApp/ViewModels/TransactionFormViewModel.swift
@@ -1,0 +1,145 @@
+//
+//  TransactionFormViewModel.swift
+//  FinApp
+//
+//  Created by Даниил Дементьев on 17.06.2025.
+//
+
+import Foundation
+import SwiftUI
+
+final class TransactionFormViewModel: ObservableObject {
+
+    @Published var categories: [Category] = []
+    @Published var selectedCategory: Category?
+    @Published var amountString = ""
+    @Published var day = Calendar.current.startOfDay(for: Date())
+    @Published var time = Date()
+    @Published var comment = ""
+    @Published var showValidationAlert = false
+    @Published var error: Error?
+    @Published private(set) var accountBrief: AccountBrief?
+
+    let mode: TransactionFormMode
+    let direction: Direction
+
+    private let transactionsService: TransactionsService
+    private let categoriesService = CategoriesService()
+    private let bankAccountService: BankAccountServiceMock
+    private let original: Transaction?
+    private let originalCategoryID: Int?
+
+    init(
+        mode: TransactionFormMode,
+        original: Transaction? = nil,
+        direction: Direction,
+        transactionsService: TransactionsService,
+        bankAccountService: BankAccountServiceMock
+    ) {
+        self.mode = mode
+        self.direction = direction
+        self.transactionsService = transactionsService
+        self.bankAccountService = bankAccountService
+        self.original = original
+        self.originalCategoryID = original?.category.id
+
+        if let tr = original {
+            amountString = String(describing: tr.amount)
+            let cal = Calendar.current
+            day = cal.startOfDay(for: tr.transactionDate)
+            time = tr.transactionDate
+            comment = tr.comment ?? ""
+            accountBrief = tr.account
+        } else {
+            Task { await loadAccount() }
+        }
+
+        Task { await loadCategories() }
+    }
+
+    private var decSep: String { Locale.current.decimalSeparator ?? "." }
+
+    var isValid: Bool {
+        selectedCategory != nil
+            && Decimal(string: amountString.replacingOccurrences(of: decSep, with: ".")) != nil
+    }
+
+    @MainActor
+    func save() async throws {
+        guard isValid else {
+            showValidationAlert = true
+            return
+        }
+
+        guard
+            let baseCat = selectedCategory,
+            let amount = Decimal(string: amountString.replacingOccurrences(of: decSep, with: ".")),
+            let account = accountBrief
+        else {
+            return
+        }
+
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.hour, .minute, .second], from: time)
+        let fullDate = cal.date(
+            bySettingHour: comps.hour ?? 0,
+            minute: comps.minute ?? 0,
+            second: comps.second ?? 0,
+            of: day
+        ) ?? day
+
+        let trimmed = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalComment = trimmed.isEmpty ? nil : trimmed
+
+        let tx = Transaction(
+            id: original?.id ?? Int.random(in: 1...Int.max),
+            account: account,
+            category: baseCat,
+            amount: amount,
+            transactionDate: fullDate,
+            comment: finalComment,
+            createdAt: original?.createdAt ?? Date(),
+            updatedAt: Date()
+        )
+
+        if mode == .create {
+            try await transactionsService.createTransaction(tx)
+        } else {
+            try await transactionsService.updateTransaction(tx)
+        }
+    }
+
+    @MainActor
+    func delete() async throws {
+        guard let id = original?.id else { return }
+        try await transactionsService.deleteTransaction(by: id)
+    }
+
+    @MainActor
+    private func loadCategories() async {
+        do {
+            let fetched = try await categoriesService.categories(for: direction)
+            categories = fetched
+            if let origID = originalCategoryID {
+                selectedCategory = fetched.first { $0.id == origID }
+            }
+        } catch {
+            self.error = error
+        }
+    }
+
+    @MainActor
+    private func loadAccount() async {
+        do {
+            let bankAcc = try await bankAccountService.fetchAccount()
+            accountBrief = AccountBrief(
+                id: bankAcc.id,
+                name: bankAcc.name,
+                balance: bankAcc.balance,
+                currency: bankAcc.currency
+            )
+        } catch {
+            self.error = error
+        }
+    }
+}

--- a/FinApp/Views/AnalysisView/AnalisysView.swift
+++ b/FinApp/Views/AnalysisView/AnalisysView.swift
@@ -1,0 +1,18 @@
+//
+//  AnalisysView.swift
+//  FinApp
+//
+//  Created by Даниил Дементьев on 10.07.2025.
+//
+
+import SwiftUI
+
+struct AnalysisView: UIViewControllerRepresentable {
+    @ObservedObject var viewModel: TransactionsStoryViewModel
+
+    func makeUIViewController(context: Context) -> AnalysisViewController {
+        AnalysisViewController(viewModel: viewModel)
+    }
+
+    func updateUIViewController(_ uiViewController: AnalysisViewController, context: Context) { }
+}

--- a/FinApp/Views/AnalysisView/AnalysisViewController.swift
+++ b/FinApp/Views/AnalysisView/AnalysisViewController.swift
@@ -1,0 +1,337 @@
+//
+//  AnalysisViewController.swift
+//  FinApp
+//
+//  Created by Даниил Дементьев on 10.07.2025.
+//
+
+import UIKit
+import Combine
+
+final class AnalysisViewController: UIViewController {
+
+    private let viewModel: TransactionsStoryViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    private let headerLabel: UILabel = {
+        let label = UILabel()
+        label.text = "title.myAnalisys".localized
+        label.font = .preferredFont(forTextStyle: .largeTitle).bold()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let infoCardView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 16
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let separator1 = AnalysisViewController.makeSeparator()
+    private let separator2 = AnalysisViewController.makeSeparator()
+
+    private lazy var startDatePicker: UIDatePicker = {
+        let picker = UIDatePicker()
+        picker.datePickerMode = .date
+        picker.translatesAutoresizingMaskIntoConstraints = false
+        picker.backgroundColor = UIColor(named: "NewAccentColor")?.withAlphaComponent(0.65)
+        picker.layer.cornerRadius = 8
+        picker.clipsToBounds = true
+        picker.addTarget(self, action: #selector(startDateChanged), for: .valueChanged)
+        return picker
+    }()
+
+    private lazy var endDatePicker: UIDatePicker = {
+        let picker = UIDatePicker()
+        picker.datePickerMode = .date
+        picker.translatesAutoresizingMaskIntoConstraints = false
+        picker.backgroundColor = UIColor(named: "NewAccentColor")?.withAlphaComponent(0.65)
+        picker.layer.cornerRadius = 8
+        picker.clipsToBounds = true
+        picker.addTarget(self, action: #selector(endDateChanged), for: .valueChanged)
+        return picker
+    }()
+
+    private let startLabel = makeLeftTitle(text: "title.start".localized)
+    private let endLabel   = makeLeftTitle(text: "title.end".localized)
+    private let sumLabel   = makeLeftTitle(text: "title.summ".localized)
+
+    private let sumValueLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        label.textAlignment = .right
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var sortControl: UISegmentedControl = {
+        let items = TransactionsStoryViewModel.SortOption.allCases.map { $0.localizedTitle }
+        let control = UISegmentedControl(items: items)
+        control.translatesAutoresizingMaskIntoConstraints = false
+        control.addTarget(self, action: #selector(sortChanged), for: .valueChanged)
+        return control
+    }()
+
+    private let operationsHeader: UILabel = {
+        let label = UILabel()
+        label.text = "title.operations".localized.uppercased()
+        label.font = .preferredFont(forTextStyle: .caption1)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .plain)
+        table.backgroundColor = .systemGray6
+        table.separatorStyle = .singleLine
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.register(TransactionCell.self,
+                       forCellReuseIdentifier: TransactionCell.reuseIdentifier)
+        return table
+    }()
+
+    private let activityIndicator: UIActivityIndicatorView = {
+        let ind = UIActivityIndicatorView(style: .large)
+        ind.hidesWhenStopped = true
+        ind.translatesAutoresizingMaskIntoConstraints = false
+        return ind
+    }()
+
+    private let errorLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.backgroundColor = .white
+        label.layer.cornerRadius = 8
+        label.clipsToBounds = true
+        label.isHidden = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    init(viewModel: TransactionsStoryViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    @available(*, unavailable, message: "Use init(viewModel:) instead")
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.separatorInset = .zero
+        tableView.rowHeight = 66
+        view.backgroundColor = .systemGray6
+        setupLayout()
+        bindViewModel()
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    private func setupLayout() {
+        view.addSubview(headerLabel)
+        view.addSubview(infoCardView)
+        view.addSubview(sortControl)
+        view.addSubview(operationsHeader)
+        view.addSubview(tableView)
+        view.addSubview(activityIndicator)
+        view.addSubview(errorLabel)
+
+        [startLabel, startDatePicker, separator1,
+         endLabel, endDatePicker, separator2,
+         sumLabel, sumValueLabel]
+            .forEach { infoCardView.addSubview($0) }
+
+        let pad: CGFloat = 16
+
+        NSLayoutConstraint.activate([
+            headerLabel.topAnchor.constraint(equalTo:
+                                                view.safeAreaLayoutGuide.topAnchor,
+                                             constant: pad),
+            headerLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: pad),
+            headerLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -pad),
+
+            infoCardView.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: pad),
+            infoCardView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: pad),
+            infoCardView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -pad),
+
+            startLabel.topAnchor.constraint(equalTo: infoCardView.topAnchor, constant: pad),
+            startLabel.leadingAnchor.constraint(equalTo: infoCardView.leadingAnchor, constant: pad),
+            startDatePicker.centerYAnchor.constraint(equalTo: startLabel.centerYAnchor),
+            startDatePicker.trailingAnchor.constraint(equalTo:
+                                                        infoCardView.trailingAnchor,
+                                                      constant: -pad),
+
+            separator1.topAnchor.constraint(equalTo: startLabel.bottomAnchor, constant: 12),
+            separator1.leadingAnchor.constraint(equalTo: infoCardView.leadingAnchor, constant: 20),
+            separator1.trailingAnchor.constraint(equalTo:
+                                                    infoCardView.trailingAnchor, constant: -20),
+            separator1.heightAnchor.constraint(equalToConstant: 1),
+
+            endLabel.topAnchor.constraint(equalTo: separator1.bottomAnchor, constant: 12),
+            endLabel.leadingAnchor.constraint(equalTo: startLabel.leadingAnchor),
+            endDatePicker.centerYAnchor.constraint(equalTo: endLabel.centerYAnchor),
+            endDatePicker.trailingAnchor.constraint(equalTo: startDatePicker.trailingAnchor),
+
+            separator2.topAnchor.constraint(equalTo: endLabel.bottomAnchor, constant: 12),
+            separator2.leadingAnchor.constraint(equalTo: infoCardView.leadingAnchor, constant: 20),
+            separator2.trailingAnchor.constraint(equalTo:
+                                                    infoCardView.trailingAnchor, constant: -20),
+            separator2.heightAnchor.constraint(equalToConstant: 1),
+
+            sumLabel.topAnchor.constraint(equalTo: separator2.bottomAnchor, constant: 12),
+            sumLabel.leadingAnchor.constraint(equalTo: startLabel.leadingAnchor),
+            sumValueLabel.centerYAnchor.constraint(equalTo: sumLabel.centerYAnchor),
+            sumValueLabel.trailingAnchor.constraint(equalTo: startDatePicker.trailingAnchor),
+            sumLabel.bottomAnchor.constraint(equalTo: infoCardView.bottomAnchor, constant: -pad),
+
+            sortControl.topAnchor.constraint(equalTo: infoCardView.bottomAnchor, constant: pad),
+            sortControl.leadingAnchor.constraint(equalTo: headerLabel.leadingAnchor),
+            sortControl.trailingAnchor.constraint(equalTo: headerLabel.trailingAnchor),
+
+            operationsHeader.topAnchor.constraint(equalTo: sortControl.bottomAnchor, constant: 20),
+            operationsHeader.leadingAnchor.constraint(equalTo: headerLabel.leadingAnchor),
+            operationsHeader.trailingAnchor.constraint(equalTo: sortControl.trailingAnchor),
+
+            tableView.topAnchor.constraint(equalTo: operationsHeader.bottomAnchor, constant: 8),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            errorLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: pad),
+            errorLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -pad),
+            errorLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+
+    private func bindViewModel() {
+        viewModel.$startDate
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.startDatePicker.date = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$endDate
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.endDatePicker.date = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$totalAmount
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in
+                self?.sumValueLabel.text = $0.formatted(.currency(code: "RUB"))
+            }
+            .store(in: &cancellables)
+
+        viewModel.$selectedSortOption
+            .receive(on: RunLoop.main)
+            .sink { [weak self] option in
+                guard let self else { return }
+                let idx = TransactionsStoryViewModel.SortOption.allCases.firstIndex(of: option) ?? 0
+                sortControl.selectedSegmentIndex = idx
+                tableView.reloadData()
+            }
+            .store(in: &cancellables)
+
+        viewModel.$transactions
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.tableView.reloadData() }
+            .store(in: &cancellables)
+
+        viewModel.$isLoading
+            .receive(on: RunLoop.main)
+            .sink { [weak self] loading in
+                loading ? self?.activityIndicator.startAnimating()
+                :
+                self?.activityIndicator.stopAnimating()
+            }
+            .store(in: &cancellables)
+
+        viewModel.$error
+            .receive(on: RunLoop.main)
+            .sink { [weak self] error in
+                self?.errorLabel.text = error.map {
+                    "error.title".localized + ": " + $0.localizedDescription }
+                self?.errorLabel.isHidden = (error == nil)
+            }
+            .store(in: &cancellables)
+    }
+
+    @objc private func startDateChanged() {
+        if startDatePicker.date > viewModel.endDate {
+            viewModel.endDate = startDatePicker.date
+        }
+        viewModel.startDate = startDatePicker.date
+        Task { await viewModel.reloadData() }
+    }
+
+    @objc private func endDateChanged() {
+        if endDatePicker.date < viewModel.startDate {
+            viewModel.startDate = endDatePicker.date
+        }
+        viewModel.endDate = endDatePicker.date
+        Task { await viewModel.reloadData() }
+    }
+
+    @objc private func sortChanged() {
+        let opt = TransactionsStoryViewModel.SortOption.allCases[sortControl.selectedSegmentIndex]
+        viewModel.selectedSortOption = opt
+    }
+
+    private static func makeLeftTitle(text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 16)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+
+    private static func makeSeparator() -> UIView {
+        let view = UIView()
+        view.backgroundColor = UIColor.separator
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }
+}
+
+extension AnalysisViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        viewModel.sortedTransactions.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: TransactionCell.reuseIdentifier,
+            for: indexPath
+        ) as? TransactionCell else {
+            return UITableViewCell()
+        }
+
+        let txn = viewModel.sortedTransactions[indexPath.row]
+        let percent = viewModel.totalAmount.doubleValue == 0 ? 0 :
+                      (txn.amount.doubleValue / viewModel.totalAmount.doubleValue) * 100
+
+        cell.configure(with: txn, direction: viewModel.direction, percent: percent)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 56
+    }
+}
+
+private extension Decimal {
+    var doubleValue: Double { (self as NSDecimalNumber).doubleValue }
+}
+
+private extension UIFont {
+    func bold() -> UIFont { with(.traitBold) }
+    private func with(_ traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
+        guard let descriptor = fontDescriptor.withSymbolicTraits(traits) else { return self }
+        return UIFont(descriptor: descriptor, size: pointSize)
+    }
+}

--- a/FinApp/Views/AnalysisView/TransactionCell.swift
+++ b/FinApp/Views/AnalysisView/TransactionCell.swift
@@ -1,0 +1,190 @@
+//
+//  TransactionCell.swift
+//  FinApp
+//
+//  Created by Даниил Дементьев on 10.07.2025.
+//
+
+import UIKit
+
+final class TransactionCell: UITableViewCell {
+
+    static let reuseIdentifier = "TransactionCell"
+
+    private let cardView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 16
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let iconContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 15
+        view.backgroundColor = UIColor(named: "NewAccentColor")?.withAlphaComponent(0.65)
+        return view
+    }()
+
+    private let iconLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        return label
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 17)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let commentLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let amountLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 17)
+        label.textAlignment = .right
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let timeLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .gray
+        label.textAlignment = .right
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let percentLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .right
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.7
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let rightStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.alignment = .trailing
+        stack.spacing = 2
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private lazy var timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = .clear
+        separatorInset = .zero
+
+        setupLayout()
+    }
+
+    @available(*, unavailable, message: "Use reuseIdentifier-based init")
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    // MARK: Layout
+    private func setupLayout() {
+        let horizontalInset: CGFloat = 16
+        let pad: CGFloat = 12
+
+        contentView.addSubview(cardView)
+        NSLayoutConstraint.activate([
+            cardView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 5),
+            cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -5),
+            cardView.leadingAnchor.constraint(equalTo:
+                                                contentView.leadingAnchor,
+                                              constant: horizontalInset),
+            cardView.trailingAnchor.constraint(equalTo:
+                                                contentView.trailingAnchor,
+                                               constant: -horizontalInset)
+        ])
+
+        cardView.addSubview(iconContainer)
+        iconContainer.addSubview(iconLabel)
+        cardView.addSubview(titleLabel)
+        cardView.addSubview(commentLabel)
+        cardView.addSubview(rightStack)
+
+        rightStack.addArrangedSubview(amountLabel)
+        rightStack.addArrangedSubview(timeLabel)
+        rightStack.addArrangedSubview(percentLabel)
+
+        NSLayoutConstraint.activate([
+            iconContainer.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: pad),
+            iconContainer.centerYAnchor.constraint(equalTo: cardView.centerYAnchor),
+            iconContainer.widthAnchor.constraint(equalToConstant: 30),
+            iconContainer.heightAnchor.constraint(equalToConstant: 30),
+
+            iconLabel.centerXAnchor.constraint(equalTo: iconContainer.centerXAnchor),
+            iconLabel.centerYAnchor.constraint(equalTo: iconContainer.centerYAnchor),
+
+            titleLabel.leadingAnchor.constraint(equalTo:
+                                                    iconContainer.trailingAnchor, constant: 12),
+            titleLabel.topAnchor.constraint(equalTo:
+                                                cardView.topAnchor, constant: 8),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo:
+                                                    rightStack.leadingAnchor, constant: -8),
+
+            commentLabel.leadingAnchor.constraint(equalTo:
+                                                    titleLabel.leadingAnchor),
+            commentLabel.topAnchor.constraint(equalTo:
+                                                titleLabel.bottomAnchor, constant: 2),
+            commentLabel.trailingAnchor.constraint(lessThanOrEqualTo:
+                                                    rightStack.leadingAnchor, constant: -8),
+
+            rightStack.topAnchor.constraint(equalTo: cardView.topAnchor, constant: 8),
+            rightStack.trailingAnchor.constraint(equalTo:
+                                                    cardView.trailingAnchor, constant: -pad),
+            rightStack.bottomAnchor.constraint(lessThanOrEqualTo:
+                                                cardView.bottomAnchor, constant: -8)
+        ])
+    }
+
+    func configure(with transaction: Transaction,
+                   direction: Direction,
+                   percent: Double) {
+
+        iconLabel.text  = String(transaction.category.emoji)
+        titleLabel.text = transaction.category.name
+
+        if let comment = transaction.comment, !comment.isEmpty {
+            commentLabel.text = comment
+            commentLabel.isHidden = false
+        } else {
+            commentLabel.isHidden = true
+        }
+
+        amountLabel.text = transaction.amount.formatted(.currency(code: "RUB"))
+
+        timeLabel.text = transaction.updatedAt > transaction.createdAt
+            ? timeFormatter.string(from: transaction.updatedAt)
+            : nil
+        timeLabel.isHidden = (timeLabel.text == nil)
+
+        percentLabel.text = String(format: "%.1f%%", percent)
+    }
+}

--- a/FinApp/Views/EditTransactionView/FloatingActionButton.swift
+++ b/FinApp/Views/EditTransactionView/FloatingActionButton.swift
@@ -1,0 +1,26 @@
+//
+//  FloatingActionButton.swift
+//  FinApp
+//
+//  Created by Даниил Дементьев on 11.07.2025.
+//
+
+import SwiftUI
+
+struct FloatingActionButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "plus")
+                .font(.system(size: 28, weight: .medium))
+                .foregroundStyle(.white)
+                .frame(width: 56, height: 56)
+                .background(Color("NewAccentColor"))
+                .clipShape(Circle())
+        }
+        .shadow(radius: 4)
+        .padding(.bottom, 34 + 12)
+        .padding(.trailing, 20)
+    }
+}

--- a/FinApp/Views/EditTransactionView/TransactionFormView.swift
+++ b/FinApp/Views/EditTransactionView/TransactionFormView.swift
@@ -1,0 +1,151 @@
+//
+//  TransactionFormView.swift
+//  FinApp
+//
+//  Created by Даниил Дементьев on 11.07.2025.
+//
+
+import SwiftUI
+
+enum TransactionFormMode { case create, edit }
+
+struct TransactionFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var listVM: TransactionsListViewModel
+    @StateObject private var vm: TransactionFormViewModel
+
+    @State private var errorMessage: String?
+
+    init(
+        mode: TransactionFormMode,
+        transaction: Transaction? = nil,
+        direction: Direction,
+        transactionsService: TransactionsService,
+        bankAccountService: BankAccountServiceMock
+    ) {
+        _vm = StateObject(
+            wrappedValue: TransactionFormViewModel(
+                mode: mode,
+                original: transaction,
+                direction: direction,
+                transactionsService: transactionsService,
+                bankAccountService: bankAccountService
+            )
+        )
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Picker("Статья", selection: $vm.selectedCategory) {
+                    Text("— выберите —").tag(nil as Category?)
+                    ForEach(vm.categories) { cat in
+                        Text("\(cat.emoji) \(cat.name)")
+                            .tag(cat as Category?)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                HStack {
+                    Text("Сумма")
+                        .font(.system(size: 17, weight: .regular))
+                    Spacer()
+                    TextField("0", text: $vm.amountString)
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .font(.system(size: 17, weight: .regular))
+                        .onChange(of: vm.amountString) { newValue in
+                            let decSep = Locale.current.decimalSeparator ?? "."
+                            var filtered = newValue.filter { char in
+                                char.isNumber || String(char) == decSep
+                            }
+                            if let firstSepIndex = filtered.firstIndex(of: Character(decSep)) {
+                                let prefix = filtered[...firstSepIndex]
+                                let suffix = filtered[filtered.index(after: firstSepIndex)...]
+                                    .filter { String($0) != decSep }
+                                filtered = String(prefix) + String(suffix)
+                            }
+                            vm.amountString = filtered
+                        }
+                }
+
+                DatePicker("Дата",
+                           selection: $vm.day,
+                           in: ...Date(),
+                           displayedComponents: .date)
+                .datePickerStyle(.compact)
+
+                DatePicker("Время",
+                           selection: $vm.time,
+                           displayedComponents: .hourAndMinute)
+                .datePickerStyle(.compact)
+
+                TextField("Комментарий", text: $vm.comment)
+                    .foregroundColor(vm.comment.isEmpty ? .secondary : .primary)
+            }
+            .navigationTitle(vm.mode == .create ? "Новая операция" : "Редактирование")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Отмена") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(vm.mode == .create ? "Создать" : "Сохранить") {
+                        if vm.isValid {
+                            Task {
+                                do {
+                                    try await vm.save()
+                                    listVM.loadTransactionsForListView()
+                                    dismiss()
+                                } catch {
+                                    errorMessage = error.localizedDescription
+                                }
+                            }
+                        } else {
+                            vm.showValidationAlert = true
+                        }
+                    }
+                }
+            }
+            .alert("Заполните все поля", isPresented: $vm.showValidationAlert) {
+                Button("ОК", role: .cancel) { }
+            }
+            .alert(
+                "Ошибка",
+                isPresented: Binding<Bool>(
+                    get: { errorMessage != nil },
+                    set: { newValue in if !newValue { errorMessage = nil } }
+                )
+            ) {
+                Button("ОК", role: .cancel) {
+                    errorMessage = nil
+                }
+            } message: {
+                Text(errorMessage ?? "Неизвестная ошибка")
+            }
+            .safeAreaInset(edge: .bottom) {
+                if vm.mode == .edit {
+                    Button {
+                        Task {
+                            do {
+                                try await vm.delete()
+                                listVM.loadTransactionsForListView()
+                                dismiss()
+                            } catch {
+                                errorMessage = error.localizedDescription
+                            }
+                        }
+                    } label: {
+                        Text(vm.direction == .income ? "Удалить доход" : "Удалить расход")
+                            .foregroundColor(.red)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.white)
+                            .cornerRadius(8)
+                    }
+                    .padding(.horizontal)
+                }
+            }
+        }
+    }
+}

--- a/FinApp/Views/TransactionListView/TransactionsListContentView.swift
+++ b/FinApp/Views/TransactionListView/TransactionsListContentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct TransactionsListContentView: View {
     @EnvironmentObject var viewModel: TransactionsListViewModel
+    let onSelect: (Transaction) -> Void
 
     var body: some View {
         Group {
@@ -21,7 +22,8 @@ struct TransactionsListContentView: View {
                     .padding()
                     .frame(maxHeight: .infinity)
             } else {
-                TransactionsListLoadedView()
+                TransactionsListLoadedView(onSelect: onSelect)
+                    .environmentObject(viewModel)
             }
         }
         .background(Color(.systemGroupedBackground))

--- a/FinApp/Views/TransactionListView/TransactionsListLoadedView.swift
+++ b/FinApp/Views/TransactionListView/TransactionsListLoadedView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct TransactionsListLoadedView: View {
     @EnvironmentObject var viewModel: TransactionsListViewModel
+    let onSelect: (Transaction) -> Void
 
     var body: some View {
         VStack {
@@ -26,15 +27,17 @@ struct TransactionsListLoadedView: View {
             let items = viewModel.transactions
             List {
                 ForEach(Array(items.enumerated()), id: \.element.id) { index, transaction in
-                    TransactionRowView(transaction: transaction,
-                                       direction: viewModel.direction)
+                    TransactionRowView(
+                        transaction: transaction,
+                        direction: viewModel.direction,
+                        onTap: { onSelect(transaction) }
+                    )
                     .listRowInsets(EdgeInsets())
                     .listRowBackground(
                         RoundedRectangle(cornerRadius: 16, style: .continuous)
                             .fill(Color.white)
                             .padding(.top, index == 0 ? 0 : -16)
-                            .padding(.bottom,
-                                     index == items.count - 1 ? 0 : -16)
+                            .padding(.bottom, index == items.count - 1 ? 0 : -16)
                             .clipShape(Rectangle())
                     )
                     .listRowSeparator(

--- a/FinApp/Views/TransactionListView/TransactionsListToolbar.swift
+++ b/FinApp/Views/TransactionListView/TransactionsListToolbar.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct TransactionsListToolbar: ToolbarContent {
     let direction: Direction
+    @EnvironmentObject var transactionsListViewModel: TransactionsListViewModel
 
     var body: some ToolbarContent {
         ToolbarItem(placement: .navigationBarTrailing) {
@@ -17,7 +18,7 @@ struct TransactionsListToolbar: ToolbarContent {
                     .environmentObject(
                         TransactionsStoryViewModel(
                             direction: direction,
-                            transactionsService: TransactionsService()
+                            transactionsService: transactionsListViewModel.transactionsService
                         )
                     )
             ) {

--- a/FinApp/Views/TransactionListView/TransactionsListView.swift
+++ b/FinApp/Views/TransactionListView/TransactionsListView.swift
@@ -10,13 +10,52 @@ import SwiftUI
 struct TransactionsListView: View {
     @EnvironmentObject var transactionsListViewModel: TransactionsListViewModel
 
+    @State private var isPresentingCreateForm = false
+    @State private var editingTransaction: Transaction?
+
     var body: some View {
         NavigationView {
-            TransactionsListContentView()
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    TransactionsListToolbar(direction: transactionsListViewModel.direction)
+            ZStack {
+                TransactionsListContentView(onSelect: { transaction in
+                    editingTransaction = transaction
+                })
+                .environmentObject(transactionsListViewModel)
+
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        FloatingActionButton {
+                            isPresentingCreateForm = true
+                        }
+                        .padding(.trailing, 20)
+                        .padding(.bottom)
+                    }
                 }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                TransactionsListToolbar(direction: transactionsListViewModel.direction)
+            }
+            .fullScreenCover(isPresented: $isPresentingCreateForm) {
+                TransactionFormView(
+                    mode: .create,
+                    direction: transactionsListViewModel.direction,
+                    transactionsService: transactionsListViewModel.transactionsService,
+                    bankAccountService: BankAccountServiceMock()
+                )
+                .environmentObject(transactionsListViewModel)
+            }
+            .fullScreenCover(item: $editingTransaction) { transaction in
+                TransactionFormView(
+                    mode: .edit,
+                    transaction: transaction,
+                    direction: transactionsListViewModel.direction,
+                    transactionsService: transactionsListViewModel.transactionsService,
+                    bankAccountService: BankAccountServiceMock()
+                )
+                .environmentObject(transactionsListViewModel)
+            }
         }
         .onAppear {
             transactionsListViewModel.loadTransactionsForListView()

--- a/FinApp/Views/TransactionRowView.swift
+++ b/FinApp/Views/TransactionRowView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct TransactionRowView: View {
     let transaction: Transaction
     let direction: Direction
+    let onTap: (() -> Void)?
 
     private var timeFormatter: Date.FormatStyle {
         Date.FormatStyle()
@@ -52,11 +53,13 @@ struct TransactionRowView: View {
                         .foregroundColor(.gray)
                 }
             }
-
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 12)
         .frame(height: 44)
         .contentShape(Rectangle())
+        .onTapGesture {
+            onTap?()
+        }
     }
 }

--- a/FinApp/Views/TransactionsStoryView/TransactionsStoryOperationsList.swift
+++ b/FinApp/Views/TransactionsStoryView/TransactionsStoryOperationsList.swift
@@ -16,7 +16,7 @@ struct TransactionsStoryOperationsList: View {
                     id: \.element.id) { index, transaction in
                 TransactionRowView(
                     transaction: transaction,
-                    direction: viewModel.direction
+                    direction: viewModel.direction, onTap: nil
                 )
                 .listRowInsets(EdgeInsets())
                 .listRowBackground(

--- a/FinApp/Views/TransactionsStoryView/TransactionsStoryView.swift
+++ b/FinApp/Views/TransactionsStoryView/TransactionsStoryView.swift
@@ -8,28 +8,49 @@
 import SwiftUI
 
 struct TransactionsStoryView: View {
-    @EnvironmentObject var transactionsStoryViewModel: TransactionsStoryViewModel
+    @EnvironmentObject var viewModel: TransactionsStoryViewModel
+    @State private var showAnalysis = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            TransactionsStoryHeader()
-            TransactionsStoryFilterCard()
-            TransactionsStoryOperationsHeader()
-            TransactionsStoryOperationsList()
-        }
-        .padding()
-        .background(Color(.systemGray6).ignoresSafeArea())
-        .overlay {
-            if transactionsStoryViewModel.isLoading {
-                ProgressView()
+        ZStack {
+            VStack(spacing: 0) {
+                TransactionsStoryFilterCard()
+                TransactionsStoryOperationsHeader()
+                TransactionsStoryOperationsList()
             }
-            if let error = transactionsStoryViewModel.error {
+            .padding(.horizontal)
+            .padding(.bottom)
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.black.opacity(0.001))
+                    .allowsHitTesting(false)
+            }
+            if let error = viewModel.error {
                 Text("error.title".localized + ": \(error.localizedDescription)")
                     .multilineTextAlignment(.center)
                     .padding()
                     .background(Color.white)
                     .cornerRadius(8)
             }
+        }
+        .sheet(isPresented: $showAnalysis) {
+            AnalysisView(viewModel: viewModel)
+        }
+        .navigationTitle("title.myHistory".localized)
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button { showAnalysis = true } label: {
+                    Image(systemName: "doc")
+                        .foregroundColor(.indigo)
+                }
+            }
+        }
+        .background(Color(.systemGray6).ignoresSafeArea())
+        .onAppear {
+            Task { await viewModel.reloadData() }
         }
     }
 }


### PR DESCRIPTION
###  Что реализовано 

* **Экран «Анализ»**

  * Полностью на UIKit (`AnalysisViewController` + `UIViewControllerRepresentable`-обёртка)
  * Настроены `UIDatePicker` для начала/конца периода с синхронизацией с `TransactionsStoryViewModel`
  * Сумма операций отображается в лейбле, операции — в `UITableView`
    * При изменении начала/конца периода автоматически корректируется противоположная дата, если нарушается порядок
    * Добавлена сегментированная сортировка по дате или по сумме прямо над списком

* **Экран создания/редактирования операции**

  * Один параметризованный `TransactionFormView` (SwiftUI) для режимов `.create` и `.edit`
  * Показ модально через `fullScreenCover` по тапу на строку (редактирование) или на «+» (создание)
  * Поля «Статья» (menu-Picker), «Сумма» (только цифры + один локальный разделитель), «Дата» и «Время» (`.compact` DatePicker), Комментарий
  * В режиме `.edit` появляется кнопка Удалить внизу (также параметризована по экранам)
  * В режиме `.create` — кнопка «Создать», которая вызывает `TransactionsService.createTransaction`
  * Все поля обязательны: при незаполненных полях показывается алерт

* **Взаимодействие со счётом**

  * В `TransactionFormViewModel` подгружается единственный счёт из `BankAccountServiceMock`
  * При создании операции используется именно этот счёт (через `AccountBrief`), а не хардкод

* **Улучшения и фиксы**

  * Замена NotificationCenter на коллбэки в списках транзакций для открытия модалки
  * Исправлен локальный десятичный разделитель в поле «Сумма» с учётом `Locale.current`
  * Настроен `pickerStyle(.menu)` и `datePickerStyle(.compact)`, чтобы не было конфликтов модальных представлений
  * Ленивая подгрузка ячеек в `UITableView` через `dequeueReusableCell`


P.S. : 
1) скорее всего получилось сделать UI не пиксель в пиксель, но в целом, я придерживался дизайна фигмы)
2) я часто встречал баг симулятора, когда клавиатура не показывается, это баг именно симулятора)) или поменяйте настройки I/O -> Keyboard -> ...
<img width="430" alt="image" src="https://github.com/user-attachments/assets/2583d354-389a-40d6-bea4-8869b8dfd069" />

3) если у вас по какой-то причине появились проблемы с иконкой settings (и начала показываться рантайм ошибка, что файл не найден), то это проблемы Xcode, просто перетащите иконку в xcassets в All Universal. На версиях по разному, у меня в проекте все норм)
<img width="748" alt="image" src="https://github.com/user-attachments/assets/2478d3ef-65b4-4f2e-b046-cc7ace39b046" />
